### PR TITLE
Implode $params['class'] (When class comes as Array)

### DIFF
--- a/src/Template/Element/Flash/default.ctp
+++ b/src/Template/Element/Flash/default.ctp
@@ -1,6 +1,9 @@
 <?php
 $class = 'message';
 if (!empty($params['class'])) {
+	if(is_array($params['class'])){
+		$params['class'] = implode(' ',$params['class']);
+	}
 	$class .= ' ' . $params['class'];
 }
 ?>


### PR DESCRIPTION
In my case the $params['class'] is an array of classes, in this case one error message appears.
`cannot convert array to string`.
I just added a test to the variable if its type is array to convert it to string by implode it with space.
